### PR TITLE
Seta o type para o creditCard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ $payment = $sale->payment(15700);
 
 // Crie uma instância de Credit Card utilizando os dados de teste
 // esses dados estão disponíveis no manual de integração
-$payment->setType(Payment::PAYMENTTYPE_CREDITCARD)
-        ->creditCard("123", "Visa")
+$payment->creditCard("123", "Visa")
         ->setExpirationDate("12/2018")
         ->setCardNumber("0000000000000001")
         ->setHolder("Fulano de Tal");

--- a/src/Cielo/API30/Ecommerce/Payment.php
+++ b/src/Cielo/API30/Ecommerce/Payment.php
@@ -153,10 +153,11 @@ class Payment implements \JsonSerializable
         $creditCard = new CreditCard();
         $creditCard->setSecurityCode($securityCode);
         $creditCard->setBrand($brand);
-        if ($this->getType() == self::PAYMENTTYPE_CREDITCARD) {
-            $this->setCreditCard($creditCard);
+        if ($this->getType() == self::PAYMENTTYPE_DEBITCARD) {
+            $this->setDebitCard($creditCard);            
         } else {
-            $this->setDebitCard($creditCard);
+            $this->setType(self::PAYMENTTYPE_CREDITCARD);
+            $this->setCreditCard($creditCard);
         }
         return $creditCard;
     }

--- a/src/Cielo/API30/Ecommerce/Payment.php
+++ b/src/Cielo/API30/Ecommerce/Payment.php
@@ -154,7 +154,7 @@ class Payment implements \JsonSerializable
         $creditCard->setSecurityCode($securityCode);
         $creditCard->setBrand($brand);
         if ($this->getType() == self::PAYMENTTYPE_DEBITCARD) {
-            $this->setDebitCard($creditCard);            
+            $this->setDebitCard($creditCard);
         } else {
             $this->setType(self::PAYMENTTYPE_CREDITCARD);
             $this->setCreditCard($creditCard);


### PR DESCRIPTION
Verifique o comment https://github.com/DeveloperCielo/API-3.0-PHP/pull/7/commits/3def0514dce63f3eb4679e0cd150f010bad2d9f7#r96605773 a partir desta alteração o método creditCard não seta mais o type para o creditCard, alterei para corrigir isso...

Se alguem estiver usando a api e atualizou para este commit possivelmente parou de funcionar a integração, da um erro "at least one payment is required"...

Exemplo de chamada:
```php
$payment->creditCard(trim($request->cvv), trim($request->card))
		->setExpirationDate($request->expiration_month.'/20'.$request->expiration_year)
		->setCardNumber(trim($request->card_number))
		->setHolder($request->nome);
```

Relacionado a #10...

Veja que da forma que eu fiz no commit ele possibilita o uso tanto de debitCard quanto o de creditCard da mesma forma que está hoje...