### PR TITLE
Adiciona suporte para desativar e alterar dia de pagamento de Recorrências

### DIFF
--- a/src/Cielo/API30/Ecommerce/CieloEcommerce.php
+++ b/src/Cielo/API30/Ecommerce/CieloEcommerce.php
@@ -1,6 +1,7 @@
 <?php
 namespace Cielo\API30\Ecommerce;
 
+use Cielo\API30\Ecommerce\Request\UpdateRecurrentPaymentRequest;
 use Cielo\API30\Merchant;
 use Cielo\API30\Ecommerce\Request\CreateSaleRequest;
 use Cielo\API30\Ecommerce\Request\QuerySaleRequest;
@@ -100,6 +101,41 @@ class CieloEcommerce
         $queryRecurrentPaymentRequest = new queryRecurrentPaymentRequest($this->merchant, $this->environment);
 
         return $queryRecurrentPaymentRequest->execute($recurrentPaymentId);
+    }
+
+    /**
+     * Deactivate a RecurrentPayment on Cielo
+     *
+     * @param string $recurrentPaymentId
+     *            The RecurrentPaymentId to be deactivated
+     *
+     * @return \Cielo\API30\Ecommerce\RecurrentPayment The RecurrentPayment with authorization, tid, etc. returned by Cielo.
+     * @throws CieloRequestException if anything gets wrong.
+     * @see <a href=
+     *      "https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error
+     *      Codes</a>
+     */
+    public function deactivateRecurrentPayment($recurrentPaymentId)
+    {
+        $deactivateRecurrentPaymentRequest = new UpdateRecurrentPaymentRequest('Deactivate', $this->merchant, $this->environment);
+
+        return $deactivateRecurrentPaymentRequest->execute($recurrentPaymentId);
+    }
+
+    /**
+     * Change the day of a RecurrentPayment on Cielo
+     *
+     * @param $recurrentPaymentId
+     * @param int $recurrencyday
+     * @return mixed
+     */
+    public function changeDayRecurrentPayment($recurrentPaymentId, $recurrencyday)
+    {
+        $changeDayRecurrentPaymentRequest = new UpdateRecurrentPaymentRequest('RecurrencyDay', $this->merchant, $this->environment);
+
+        $changeDayRecurrentPaymentRequest->setContent($recurrencyday);
+
+        return $changeDayRecurrentPaymentRequest->execute($recurrentPaymentId);
     }
 
     /**

--- a/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
@@ -5,17 +5,17 @@ use Cielo\API30\Merchant;
 use Cielo\API30\Ecommerce\Sale;
 
 /**
- * Class AbstractSaleRequest
+ * Class AbstractRequest
  *
  * @package Cielo\API30\Ecommerce\Request
  */
-abstract class AbstractSaleRequest
+abstract class AbstractRequest
 {
 
     private $merchant;
 
     /**
-     * AbstractSaleRequest constructor.
+     * AbstractRequest constructor.
      *
      * @param Merchant $merchant
      */
@@ -41,14 +41,14 @@ abstract class AbstractSaleRequest
     /**
      * @param $method
      * @param $url
-     * @param Sale|null $sale
+     * @param mixed|null $content
      *
      * @return mixed
      *
      * @throws \Cielo\API30\Ecommerce\Request\CieloRequestException
      * @throws \RuntimeException
      */
-    protected function sendRequest($method, $url, Sale $sale = null)
+    protected function sendRequest($method, $url, $content = null)
     {
         $headers = [
             'Accept: application/json',
@@ -74,8 +74,8 @@ abstract class AbstractSaleRequest
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
         }
 
-        if ($sale !== null) {
-            curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($sale));
+        if ($content !== null) {
+            curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($content));
 
             $headers[] = 'Content-Type: application/json';
         } else {

--- a/src/Cielo/API30/Ecommerce/Request/CreateSaleRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/CreateSaleRequest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cielo\API30\Ecommerce\Request;
 
-use Cielo\API30\Ecommerce\Request\AbstractSaleRequest;
+use Cielo\API30\Ecommerce\Request\AbstractRequest;
 use Cielo\API30\Environment;
 use Cielo\API30\Merchant;
 use Cielo\API30\Ecommerce\Sale;
@@ -11,7 +11,7 @@ use Cielo\API30\Ecommerce\Sale;
  *
  * @package Cielo\API30\Ecommerce\Request
  */
-class CreateSaleRequest extends AbstractSaleRequest
+class CreateSaleRequest extends AbstractRequest
 {
 
     private $environment;

--- a/src/Cielo/API30/Ecommerce/Request/QueryRecurrentPaymentRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/QueryRecurrentPaymentRequest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cielo\API30\Ecommerce\Request;
 
-use Cielo\API30\Ecommerce\Request\AbstractSaleRequest;
+use Cielo\API30\Ecommerce\Request\AbstractRequest;
 use Cielo\API30\Environment;
 use Cielo\API30\Merchant;
 use Cielo\API30\Ecommerce\RecurrentPayment;
@@ -11,7 +11,7 @@ use Cielo\API30\Ecommerce\RecurrentPayment;
  *
  * @package Cielo\API30\Ecommerce\Request
  */
-class QueryRecurrentPaymentRequest extends AbstractSaleRequest
+class QueryRecurrentPaymentRequest extends AbstractRequest
 {
 
     private $environment;

--- a/src/Cielo/API30/Ecommerce/Request/QuerySaleRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/QuerySaleRequest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cielo\API30\Ecommerce\Request;
 
-use Cielo\API30\Ecommerce\Request\AbstractSaleRequest;
+use Cielo\API30\Ecommerce\Request\AbstractRequest;
 use Cielo\API30\Environment;
 use Cielo\API30\Merchant;
 use Cielo\API30\Ecommerce\Sale;
@@ -11,7 +11,7 @@ use Cielo\API30\Ecommerce\Sale;
  *
  * @package Cielo\API30\Ecommerce\Request
  */
-class QuerySaleRequest extends AbstractSaleRequest
+class QuerySaleRequest extends AbstractRequest
 {
 
     private $environment;

--- a/src/Cielo/API30/Ecommerce/Request/UpdateRecurrentPaymentRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/UpdateRecurrentPaymentRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Cielo\API30\Ecommerce\Request;
+
+use Cielo\API30\Ecommerce\Request\AbstractRequest;
+use Cielo\API30\Environment;
+use Cielo\API30\Merchant;
+use Cielo\API30\Ecommerce\RecurrentPayment;
+
+class UpdateRecurrentPaymentRequest extends AbstractRequest
+{
+
+    private $environment;
+
+    private $type;
+
+    private $content;
+
+    public function __construct($type, Merchant $merchant, Environment $environment)
+    {
+        parent::__construct($merchant);
+
+        $this->environment = $environment;
+        $this->type = $type;
+        $this->content = null;
+    }
+
+    public function execute($recurrentPaymentId)
+    {
+        $url = $this->environment->getApiURL() . '1/RecurrentPayment/' . $recurrentPaymentId . '/' . $this->type;
+
+        return $this->sendRequest('PUT', $url, $this->content);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param mixed $content
+     * @return mixed|null
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+        return $this->content;
+    }
+
+    /**
+     * @param $json
+     * @return RecurrentPayment
+     */
+    protected function unserialize($json)
+    {
+        return RecurrentPayment::fromJson($json);
+    }
+
+}

--- a/src/Cielo/API30/Ecommerce/Request/UpdateSaleRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/UpdateSaleRequest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cielo\API30\Ecommerce\Request;
 
-use Cielo\API30\Ecommerce\Request\AbstractSaleRequest;
+use Cielo\API30\Ecommerce\Request\AbstractRequest;
 use Cielo\API30\Environment;
 use Cielo\API30\Merchant;
 use Cielo\API30\Ecommerce\Payment;
@@ -11,7 +11,7 @@ use Cielo\API30\Ecommerce\Payment;
  *
  * @package Cielo\API30\Ecommerce\Request
  */
-class UpdateSaleRequest extends AbstractSaleRequest
+class UpdateSaleRequest extends AbstractRequest
 {
 
     private $environment;


### PR DESCRIPTION
Acrescentei nova interface para requisições de modificar recorrência e novos métodos para implementar requisições de desativar recorrência e alterar dia de pagamento na classe CieloEcommerce.

Obs: foi preciso alterar a classe abstrata base das requests para deixá-la mais genérica, pois ela necessitava de um parâmetro específico do tipo Sale.