### PR TITLE
Melhoria na nomenclatura do exemplo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $environment = $environment = Environment::sandbox();
 // Configure seu merchant
 $merchant = new Merchant('MERCHANT ID', 'MERCHANT KEY');
 
-// Crie uma instância de Sale informando o ID do pagamento
+// Crie uma instância de Sale informando o ID do pedido na loja
 $sale = new Sale('123');
 
 // Crie uma instância de Customer informando o nome do cliente
@@ -130,7 +130,7 @@ $environment = $environment = Environment::sandbox();
 // Configure seu merchant
 $merchant = new Merchant('MERCHANT ID', 'MERCHANT KEY');
 
-// Crie uma instância de Sale informando o ID do pagamento
+// Crie uma instância de Sale informando o ID do pedido na loja
 $sale = new Sale('123');
 
 // Crie uma instância de Customer informando o nome do cliente
@@ -185,7 +185,7 @@ $environment = $environment = Environment::sandbox();
 // Configure seu merchant
 $merchant = new Merchant('MERCHANT ID', 'MERCHANT KEY');
 
-// Crie uma instância de Sale informando o ID do pagamento
+// Crie uma instância de Sale informando o ID do pedido na loja
 $sale = new Sale('123');
 
 // Crie uma instância de Customer informando o nome do cliente
@@ -238,7 +238,7 @@ $environment = $environment = Environment::sandbox();
 // Configure seu merchant
 $merchant = new Merchant('MID', 'MKEY');
 
-// Crie uma instância de Sale informando o ID do pagamento
+// Crie uma instância de Sale informando o ID do pedido na loja
 $sale = new Sale('123');
 
 // Crie uma instância de Customer informando o nome do cliente
@@ -294,7 +294,7 @@ $environment = $environment = Environment::sandbox();
 // Configure seu merchant
 $merchant = new Merchant('MERCHANT ID', 'MERCHANT KEY');
 
-// Crie uma instância de Sale informando o ID do pagamento
+// Crie uma instância de Sale informando o ID do pedido na loja
 $sale = new Sale('123');
 
 // Crie uma instância de Customer informando o nome do cliente
@@ -355,7 +355,7 @@ $environment = $environment = Environment::sandbox();
 // Configure seu merchant
 $merchant = new Merchant('MERCHANT ID', 'MERCHANT KEY');
 
-// Crie uma instância de Sale informando o ID do pagamento
+// Crie uma instância de Sale informando o ID do pedido na loja
 $sale = new Sale('123');
 
 // Crie uma instância de Customer informando o nome do cliente,


### PR DESCRIPTION
Creio que existe esse pequeno erro na nomenclatura dos exemplos.
Não faz sentido eu ter que informar o ID do pagamento (que não existe ainda), sendo que posteriormente eu irei criar um novo pagamento com base nos dados capturados.
Acredito que o correto seja passar o ID do pedido na loja.
Desculpe-me se eu estiver equivocado.