### PR TITLE
Adiciona suporte para desativar, reativar, alterar o dia de cobrança e valor de pagamentos recorrentes

### DIFF
--- a/src/Cielo/API30/Ecommerce/CieloEcommerce.php
+++ b/src/Cielo/API30/Ecommerce/CieloEcommerce.php
@@ -7,6 +7,7 @@ use Cielo\API30\Ecommerce\Request\QueryRecurrentPaymentRequest;
 use Cielo\API30\Ecommerce\Request\QuerySaleRequest;
 use Cielo\API30\Ecommerce\Request\TokenizeCardRequest;
 use Cielo\API30\Ecommerce\Request\UpdateSaleRequest;
+use Cielo\API30\Ecommerce\Request\UpdateRecurrentPaymentRequest;
 use Cielo\API30\Merchant;
 
 /**
@@ -170,5 +171,75 @@ class CieloEcommerce
         $tokenizeCardRequest = new TokenizeCardRequest($this->merchant, $this->environment);
 
         return $tokenizeCardRequest->execute($card);
+    }
+
+    /**
+     * Deactivate a RecurrentPayment on Cielo
+     *
+     * @param string $recurrentPaymentId
+     *            The RecurrentPaymentId to be deactivated
+     *
+     * @return \Cielo\API30\Ecommerce\RecurrentPayment The RecurrentPayment with authorization, tid, etc. returned by Cielo.
+     * @throws CieloRequestException if anything gets wrong.
+     * @see <a href=
+     *      "https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error
+     *      Codes</a>
+     */
+    public function deactivateRecurrentPayment($recurrentPaymentId)
+    {
+        $deactivateRecurrentPaymentRequest = new UpdateRecurrentPaymentRequest('Deactivate', $this->merchant, $this->environment);
+
+        return $deactivateRecurrentPaymentRequest->execute($recurrentPaymentId);
+    }
+
+    /**
+     * Reactivate a RecurrentPayment on Cielo
+     *
+     * @param string $recurrentPaymentId
+     *            The RecurrentPaymentId to be reactivated
+     *
+     * @return \Cielo\API30\Ecommerce\RecurrentPayment The RecurrentPayment with authorization, tid, etc. returned by Cielo.
+     * @throws CieloRequestException if anything gets wrong.
+     * @see <a href=
+     *      "https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error
+     *      Codes</a>
+     */
+    public function reactivateRecurrentPayment($recurrentPaymentId)
+    {
+        $reactivateRecurrentPaymentRequest = new UpdateRecurrentPaymentRequest('Reactivate', $this->merchant, $this->environment);
+
+        return $reactivateRecurrentPaymentRequest->execute($recurrentPaymentId);
+    }
+
+    /**
+     * Change the day of a RecurrentPayment on Cielo
+     *
+     * @param $recurrentPaymentId
+     * @param int $recurrencyday
+     * @return mixed
+     */
+    public function changeDayRecurrentPayment($recurrentPaymentId, $recurrencyday)
+    {
+        $changeDayRecurrentPaymentRequest = new UpdateRecurrentPaymentRequest('RecurrencyDay', $this->merchant, $this->environment);
+
+        $changeDayRecurrentPaymentRequest->setContent($recurrencyday);
+
+        return $changeDayRecurrentPaymentRequest->execute($recurrentPaymentId);
+    }
+
+    /**
+     * Change the amount of a RecurrentPayment on Cielo
+     *
+     * @param $recurrentPaymentId
+     * @param int $amount
+     * @return mixed
+     */
+    public function changeAmountRecurrentPayment($recurrentPaymentId, $amount)
+    {
+        $changeAmountRecurrentPaymentRequest = new UpdateRecurrentPaymentRequest('Amount', $this->merchant, $this->environment);
+
+        $changeAmountRecurrentPaymentRequest->setContent($amount);
+
+        return $changeAmountRecurrentPaymentRequest->execute($recurrentPaymentId);
     }
 }

--- a/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
@@ -5,7 +5,7 @@ namespace Cielo\API30\Ecommerce\Request;
 use Cielo\API30\Merchant;
 
 /**
- * Class AbstractSaleRequest
+ * Class AbstractRequest
  *
  * @package Cielo\API30\Ecommerce\Request
  */
@@ -15,7 +15,7 @@ abstract class AbstractRequest
     private $merchant;
 
     /**
-     * AbstractSaleRequest constructor.
+     * AbstractRequest constructor.
      *
      * @param Merchant $merchant
      */

--- a/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
@@ -32,16 +32,16 @@ abstract class AbstractRequest
     public abstract function execute($param);
 
     /**
-     * @param                        $method
-     * @param                        $url
-     * @param \JsonSerializable|null $content
+     * @param                            $method
+     * @param                            $url
+     * @param \JsonSerializable|int|null $content
      *
      * @return mixed
      *
      * @throws \Cielo\API30\Ecommerce\Request\CieloRequestException
      * @throws \RuntimeException
      */
-    protected function sendRequest($method, $url, \JsonSerializable $content = null)
+    protected function sendRequest($method, $url, $content = null)
     {
         $headers = [
             'Accept: application/json',

--- a/src/Cielo/API30/Ecommerce/Request/UpdateRecurrentPaymentRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/UpdateRecurrentPaymentRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Cielo\API30\Ecommerce\Request;
+
+use Cielo\API30\Ecommerce\RecurrentPayment;
+use Cielo\API30\Environment;
+use Cielo\API30\Merchant;
+
+/**
+ * Class UpdateRecurrentPaymentRequest
+ *
+ * @package Cielo\API30\Ecommerce\Request
+ */
+class UpdateRecurrentPaymentRequest extends AbstractRequest
+{
+
+    private $environment;
+
+    private $type;
+
+    private $content;
+
+    /**
+     * UpdateRecurrentPaymentRequest constructor.
+     *
+     * @param             $type
+     * @param Merchant    $merchant
+     * @param Environment $environment
+     */
+    public function __construct($type, Merchant $merchant, Environment $environment)
+    {
+        parent::__construct($merchant);
+
+        $this->environment = $environment;
+        $this->type = $type;
+        $this->content = null;
+    }
+
+    /**
+     * @param $recurrentPaymentId
+     *
+     * @return null
+     * @throws \Cielo\API30\Ecommerce\Request\CieloRequestException
+     * @throws \RuntimeException
+     */
+    public function execute($recurrentPaymentId)
+    {
+        $url = $this->environment->getApiURL() . '1/RecurrentPayment/' . $recurrentPaymentId . '/' . $this->type;
+
+        return $this->sendRequest('PUT', $url, $this->content);
+    }
+
+    /**
+     * @param $json
+     * @return RecurrentPayment
+     */
+    protected function unserialize($json)
+    {
+        return RecurrentPayment::fromJson($json);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param mixed $content
+     * @return mixed|null
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+        return $this->content;
+    }
+}


### PR DESCRIPTION
Acrescentei uma uma classe base para tratar de requisições de atualização de recorrências e 4 novos métodos para implementar as seguintes operações:

- Desativar recorrência
- Reativar recorrência
- Alterar data de cobrança da recorrência
- Alterar o valor da recorrência

Precisei remover a restrição de tipo JsonSerializable do parâmetro content do método sendRequest, pois na atualização de recorrências, algumas requisições (ex: alterar data e valor) enviam apenas um inteiro no body da requisição (https://developercielo.github.io/manual/cielo-ecommerce#modificando-o-valor-da-recorr%C3%AAncia). Essa restrição causa erro de execução no código. Dei uma pesquisada para saber qual seria a melhor saída e, para evitar de acrescentar uma classe para implementar essa interface para inteiro no pacote, achei melhor remover a restrição.