### PR TITLE
Adicionar suporte ao ExternalAuthentication

### DIFF
--- a/src/Cielo/API30/Ecommerce/ExternalAuthentication.php
+++ b/src/Cielo/API30/Ecommerce/ExternalAuthentication.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Cielo\API30\Ecommerce;
+
+/**
+ * Class CreditCard
+ *
+ * @package Cielo\API30\Ecommerce
+ */
+class ExternalAuthentication implements \JsonSerializable, CieloSerializable
+{
+    /** @var string $cavv */
+    private $cavv;
+
+    /** @var string $xid */
+    private $xid;
+
+    /** @var string $eci */
+    private $eci;
+
+    /** @var string $version */
+    private $version;
+
+    /** @var string $referenceId */
+    private $referenceId;
+
+    /**
+     * @param string $json
+     *
+     * @return ExternalAuthentication
+     */
+    public static function fromJson($json)
+    {
+        $object = \json_decode($json);
+        $externalAuthentication = new ExternalAuthentication();
+        $externalAuthentication->populate($object);
+
+        return $externalAuthentication;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function populate(\stdClass $data)
+    {
+        $this->cavv        = isset($data->Cavv)        ? $data->Cavv        : null;
+        $this->xid         = isset($data->Xid)         ? $data->Xid         : null;
+        $this->eci         = isset($data->Eci)         ? $data->Eci         : null;
+        $this->version     = isset($data->Version)     ? $data->Version     : null;
+        $this->referenceId = isset($data->ReferenceId) ? $data->ReferenceId : null;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCavv(): string
+    {
+        return $this->cavv;
+    }
+
+    /**
+     * @param string $cavv
+     */
+    public function setCavv(string $cavv): void
+    {
+        $this->cavv = $cavv;
+    }
+
+    /**
+     * @return string
+     */
+    public function getXid(): string
+    {
+        return $this->xid;
+    }
+
+    /**
+     * @param string $xid
+     */
+    public function setXid(string $xid): void
+    {
+        $this->xid = $xid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEci(): string
+    {
+        return $this->eci;
+    }
+
+    /**
+     * @param string $eci
+     */
+    public function setEci(string $eci): void
+    {
+        $this->eci = $eci;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param string $version
+     */
+    public function setVersion(string $version): void
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReferenceId(): string
+    {
+        return $this->referenceId;
+    }
+
+    /**
+     * @param string $referenceId
+     */
+    public function setReferenceId(string $referenceId): void
+    {
+        $this->referenceId = $referenceId;
+    }
+}

--- a/src/Cielo/API30/Ecommerce/Payment.php
+++ b/src/Cielo/API30/Ecommerce/Payment.php
@@ -40,6 +40,8 @@ class Payment implements \JsonSerializable
 
     private $creditCard;
 
+    private $externalAuthentication;
+
     private $debitCard;
 
     private $authenticationUrl;
@@ -159,6 +161,11 @@ class Payment implements \JsonSerializable
         if (isset($data->DebitCard)) {
             $this->debitCard = new CreditCard();
             $this->debitCard->populate($data->DebitCard);
+        }
+
+        if (isset($data->ExternalAuthentication)) {
+            $this->externalAuthentication = new ExternalAuthentication();
+            $this->externalAuthentication->populate($data->ExternalAuthentication);
         }
 
         $this->expirationDate = isset($data->ExpirationDate) ? $data->ExpirationDate : null;
@@ -421,6 +428,26 @@ class Payment implements \JsonSerializable
     public function setCreditCard(CreditCard $creditCard)
     {
         $this->creditCard = $creditCard;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getExternalAuthentication()
+    {
+        return $this->externalAuthentication;
+    }
+
+    /**
+     * @param ExternalAuthentication $externalAuthentication
+     *
+     * @return $this
+     */
+    public function setExternalAuthentication(ExternalAuthentication $externalAuthentication)
+    {
+        $this->externalAuthentication = $externalAuthentication;
 
         return $this;
     }


### PR DESCRIPTION
Este PR adiciona suporte ao ExternalAuthentication no Payment, a fim de prover compatiblidade com o 3DS.