### PR TITLE
Adicionar suporte para Consulta Bin

### DIFF
--- a/src/Cielo/API30/Ecommerce/CieloEcommerce.php
+++ b/src/Cielo/API30/Ecommerce/CieloEcommerce.php
@@ -176,4 +176,26 @@ class CieloEcommerce
 
         return $tokenizeCardRequest->execute($card);
     }
+
+     /**
+     * Validate credit or debit card data
+     *
+     * @param string $cardBin
+     *            First 6 digits of the payment card.
+     *   To simulate the request obtaining ForeignCard=false result, the third digit must be 1 and the fifth must not be 2 or 3.
+     *   Examples:001040, 501010, 401050
+     * 
+     * 
+     * @return json card info
+     * @throws CieloRequestException if anything gets wrong.
+     * @see <a href=
+     *      "https://developercielo.github.io/Webservice-3.0/english.html#error-codes">Error
+     *      Codes</a>
+     */
+    public function binChecker($cardBin)
+    {
+        $cieloBinRequest = new CieloBinRequest($this->merchant,$this->environment);        
+        
+        return $cieloBinRequest->execute($cardBin);
+    }
 }

--- a/src/Cielo/API30/Ecommerce/Request/CieloBinRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/CieloBinRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Cielo\API30\Ecommerce\Request;
+
+use Cielo\API30\Ecommerce\RecurrentPayment;
+use Cielo\API30\Environment;
+use Cielo\API30\Merchant;
+
+/**
+ * Class CieloBinRequest
+ *
+ * @package Cielo\API30\Ecommerce\Request
+ */
+class CieloBinRequest extends AbstractRequest
+{
+
+    private $environment;    
+
+    private $content;
+
+    /**
+     * UpdateRecurrentPaymentRequest constructor.
+     *
+     * @param             $type
+     * @param Merchant    $merchant
+     * @param Environment $environment
+     */
+    public function __construct(Merchant $merchant, Environment $environment)
+    {
+        parent::__construct($merchant);
+
+        $this->environment = $environment;        
+        $this->content = null;
+    }
+
+    /**
+     * @param $cardBin
+     *
+     * @return null
+     * @throws \Cielo\API30\Ecommerce\Request\CieloRequestException
+     * @throws \RuntimeException
+     */
+    public function execute($cardBin)
+    {        
+        $url = $this->environment->getApiQueryURL() . '1/cardBin/' . $cardBin ;
+
+        return $this->sendRequest('GET', $url, $this->content);
+    }
+
+    /**
+     * @param $json
+     * @return json 
+     */
+    protected function unserialize($json)
+    {        
+        return json_decode($json);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param mixed $content
+     * @return mixed|null
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+        return $this->content;
+    }
+}


### PR DESCRIPTION
Adicionada uma classe para as requisições de 'Consulta Bin' e um método para realizar a consulta ('binChecker($cardBin)')

Fiquei na dúvida se o método deveria ser colocado na classe CieloEcommerce ou em outra. Fico no aguardo.