### PR TITLE
Verificar se logger é nulo ao registrar curl_errno

### DIFF
--- a/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
@@ -104,8 +104,10 @@ abstract class AbstractRequest
         if (curl_errno($curl)) {
             $message = sprintf('cURL error[%s]: %s', curl_errno($curl), curl_error($curl));
 
-            $this->logger->error($message);
-
+            if ($this->logger !== null) {
+                $this->logger->error($message);
+            }
+		
             throw new \RuntimeException($message);
         }
 


### PR DESCRIPTION
O logger é utilizado três vezes nesse arquivo, porém nas demais vezes antes de utiliza-lo é verificado se ele não é nulo. 
Nessa alteração inclui a verificação no único ponto onde ela não era realizada para evitar um erro a mais.