### PR TITLE
Evitando Logger quando não existir (nulo)

### DIFF
--- a/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
+++ b/src/Cielo/API30/Ecommerce/Request/AbstractRequest.php
@@ -103,9 +103,11 @@ abstract class AbstractRequest
 
         if (curl_errno($curl)) {
             $message = sprintf('cURL error[%s]: %s', curl_errno($curl), curl_error($curl));
-
-            $this->logger->error($message);
-
+	
+	    if ($this->logger !== null) {
+            	$this->logger->error($message);
+	    }
+		
             throw new \RuntimeException($message);
         }
 


### PR DESCRIPTION
No Abstract, quando é retornado algum erro do curl, está tentando executar o logger, sem primeiramente verificar ele não é um objeto nulo.